### PR TITLE
fix: Satisfied mypy type hint errors and add preposition parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv/
 # Ignore Python's build/install metadata folders
 *.egg-info/
 /axiom_agent.egg-info/
+.coverage
 # -----------------------------------------------------------------------------
 # Project-Specific Data & Models
 # -----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 
 [project]
 name = "axiom"
-version = "0.1.1"
-description = "A cognitive architecture for a new type of AI designed for self-directed learning."
+version = "0.1.2"
+description = "A cognitive architecture for a new type of symboli-first AI designed for self-directed learning."
 authors = [
     { name = "Victor Nevarez", email = "vicsanity623@gmail.com" },
 ]

--- a/setup/app_model.py
+++ b/setup/app_model.py
@@ -7,22 +7,30 @@ import json
 import os
 import sys
 import zipfile
+from pathlib import Path
+from typing import Any, Final
 
-from flask import Flask, jsonify, render_template, request, send_from_directory
+from flask import (
+    Flask,
+    Response,
+    jsonify,
+    render_template,
+    request,
+    send_from_directory,
+)
 
 from axiom.cognitive_agent import CognitiveAgent
 
-axiom_agent = None
+axiom_agent: CognitiveAgent | None = None
 
-STATIC_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
-TEMPLATE_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "templates"),
-)
+THIS_FILE: Final = Path(__file__).absolute()
+STATIC_DIR: Final = THIS_FILE.parent / "static"
+TEMPLATE_DIR = THIS_FILE.parent / "templates"
 
 app = Flask(__name__, template_folder=TEMPLATE_DIR, static_folder=STATIC_DIR)
 
 
-def find_latest_model(directory="rendered"):
+def find_latest_model(directory: str = "rendered") -> str | None:
     """Find and return the path to the most recent .axm model file.
 
     Scans the specified directory for files matching the 'axiom_model_*.axm'
@@ -51,7 +59,7 @@ def find_latest_model(directory="rendered"):
     return latest_file
 
 
-def load_axiom_model(axm_filepath):
+def load_axiom_model(axm_filepath: str) -> tuple[Any, Any] | None:
     """Load and unpack an Axiom Mind (.axm) model file.
 
     Reads the specified .axm file (which is a zip archive) and extracts
@@ -84,25 +92,25 @@ def load_axiom_model(axm_filepath):
 
 
 @app.route("/")
-def index():
+def index() -> str:
     """Serve the main single-page application HTML."""
     return render_template("index.html")
 
 
 @app.route("/manifest.json")
-def manifest():
+def manifest() -> Response:
     """Serve the PWA manifest file for web app installation."""
     return send_from_directory(STATIC_DIR, "manifest.json")
 
 
 @app.route("/sw.js")
-def service_worker():
+def service_worker() -> Response:
     """Serve the service worker script for PWA offline capabilities."""
     return send_from_directory(STATIC_DIR, "sw.js")
 
 
 @app.route("/chat", methods=["POST"])
-def chat():
+def chat() -> tuple[Response, int] | Response:
     """Handle incoming user messages and return the agent's response.
 
     This is the main API endpoint for conversation. It expects a JSON
@@ -116,6 +124,10 @@ def chat():
     """
     if not axiom_agent:
         return jsonify({"error": "Agent is not available or is still loading."}), 503
+
+    if request.json is None:
+        return jsonify({"error": "request.json is None"}), 503
+
     user_message = request.json.get("message")
     if not user_message:
         return jsonify({"error": "No message provided."}), 400
@@ -131,7 +143,7 @@ def chat():
 
 
 @app.route("/status")
-def status():
+def status() -> Response:
     """Provide the current loading status of the agent.
 
     This endpoint allows the front-end to poll the server to determine
@@ -145,26 +157,34 @@ def status():
     return jsonify({"status": "ready" if axiom_agent else "loading_model"})
 
 
-if __name__ == "__main__":
+def run() -> int:
+    """Run webserver."""
+    global axiom_agent
+
     latest_model_path = find_latest_model()
     if not latest_model_path:
         print(
             "--- [Server]: Shutting down. Please run a trainer to generate a model first.",
         )
-        sys.exit(1)
+        return 1
 
     model_data = load_axiom_model(latest_model_path)
 
-    if model_data:
-        brain, cache = model_data
-        print("--- [Server]: Initializing agent in INFERENCE-ONLY mode... ---")
-        axiom_agent = CognitiveAgent(
-            load_from_file=False,
-            brain_data=brain,
-            cache_data=cache,
-            inference_mode=True,
-        )
-        print("--- [Server]: Agent is ready. Starting web server... ---")
-        app.run(host="0.0.0.0", port=7501, debug=False)
-    else:
-        sys.exit(1)
+    if not model_data:
+        return 1
+
+    brain, cache = model_data
+    print("--- [Server]: Initializing agent in INFERENCE-ONLY mode... ---")
+    axiom_agent = CognitiveAgent(
+        load_from_file=False,
+        brain_data=brain,
+        cache_data=cache,
+        inference_mode=True,
+    )
+    print("--- [Server]: Agent is ready. Starting web server... ---")
+    app.run(host="0.0.0.0", port=7501, debug=False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/setup/app_model.py
+++ b/setup/app_model.py
@@ -23,9 +23,10 @@ from axiom.cognitive_agent import CognitiveAgent
 
 axiom_agent: CognitiveAgent | None = None
 
-THIS_FILE: Final = Path(__file__).absolute()
-STATIC_DIR: Final = THIS_FILE.parent / "static"
-TEMPLATE_DIR = THIS_FILE.parent / "templates"
+THIS_FILE: Final = Path(__file__).resolve()
+PROJECT_ROOT: Final = THIS_FILE.parent.parent
+STATIC_DIR: Final = PROJECT_ROOT / "static"
+TEMPLATE_DIR: Final = PROJECT_ROOT / "templates"
 
 app = Flask(__name__, template_folder=TEMPLATE_DIR, static_folder=STATIC_DIR)
 

--- a/setup/autonomous_trainer.py
+++ b/setup/autonomous_trainer.py
@@ -3,35 +3,36 @@ from __future__ import annotations
 # autonomous_trainer.py
 import threading
 import time
+import traceback
 from pathlib import Path
+from typing import Final
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
 from axiom.cognitive_agent import CognitiveAgent
 from axiom.knowledge_harvester import KnowledgeHarvester
 
+BRAIN_PATH: Final = Path("brain")
+BRAIN_FILE: Final = BRAIN_PATH / "my_agent_brain.json"
+STATE_FILE: Final = BRAIN_PATH / "my_agent_state.json"
 
-def start_autonomous_training() -> None:
+
+def start_autonomous_training(brain_file: Path, state_file: Path) -> None:
     """Initialize the agent and run its autonomous learning cycles indefinitely.
 
     This script runs the Axiom Agent in a "headless" mode, with no user
     interaction. It loads the agent in its learning-enabled state,
-    schedules the recurring Study and Discovery cycles, and then enters an
-    infinite loop to keep the process alive.
+    schedules the recurring Study and Discovery cycles, and then enters
+    an infinite loop to keep the process alive.
 
     This is the primary method for enabling the agent's 24/7,
     unattended self-improvement.
     """
     print("--- [AUTONOMOUS TRAINER]: Starting Axiom Agent Initialization... ---")
 
-    axiom_agent: CognitiveAgent | None = None
     agent_interaction_lock = threading.Lock()
 
     try:
-        brain_path = Path("brain")
-        brain_file = brain_path / "my_agent_brain.json"
-        state_file = brain_path / "my_agent_state.json"
-
         axiom_agent = CognitiveAgent(
             brain_file=brain_file,
             state_file=state_file,
@@ -69,12 +70,10 @@ def start_autonomous_training() -> None:
         print("\n--- [AUTONOMOUS TRAINER]: Shutdown signal received. Exiting. ---")
     except Exception as exc:
         print(f"!!! [AUTONOMOUS TRAINER]: CRITICAL ERROR: {exc} !!!")
-        import traceback
-
         traceback.print_exc()
     finally:
         print("--- [AUTONOMOUS TRAINER]: Process terminated. ---")
 
 
 if __name__ == "__main__":
-    start_autonomous_training()
+    start_autonomous_training(BRAIN_FILE, STATE_FILE)

--- a/setup/autonomous_trainer.py
+++ b/setup/autonomous_trainer.py
@@ -22,8 +22,8 @@ def start_autonomous_training(brain_file: Path, state_file: Path) -> None:
 
     This script runs the Axiom Agent in a "headless" mode, with no user
     interaction. It loads the agent in its learning-enabled state,
-    schedules the recurring Study and Discovery cycles, and then enters
-    an infinite loop to keep the process alive.
+    schedules the recurring Study, Discovery, and Refinement cycles, and then
+    enters an infinite loop to keep the process alive.
 
     This is the primary method for enabling the agent's 24/7,
     unattended self-improvement.
@@ -48,6 +48,15 @@ def start_autonomous_training(brain_file: Path, state_file: Path) -> None:
             minutes=6,
         )
         print("--- [SCHEDULER]: Study Cycle is scheduled to run every 6 minutes. ---")
+
+        scheduler.add_job(
+            harvester.refinement_cycle,
+            "interval",
+            minutes=15,
+        )
+        print(
+            "--- [SCHEDULER]: Refinement Cycle is scheduled to run every 15 minutes. ---",
+        )
 
         scheduler.add_job(
             harvester.discover_cycle,

--- a/setup/cnt.py
+++ b/setup/cnt.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import traceback
+
 # app.py (Command-Line Manual Trainer)
 from axiom.cognitive_agent import CognitiveAgent
 
@@ -21,10 +23,8 @@ def run_training_session() -> None:
         axiom_agent = CognitiveAgent(inference_mode=False)
         print("--- [TRAINER]: Agent initialized. You can now begin training. ---")
         print("--- [TRAINER]: Type 'quit' or 'exit' to save and end the session. ---")
-    except Exception as e:
-        print(f"!!! [TRAINER]: CRITICAL ERROR during initialization: {e} !!!")
-        import traceback
-
+    except Exception as exc:
+        print(f"!!! [TRAINER]: CRITICAL ERROR during initialization: {exc} !!!")
         traceback.print_exc()
         return
 
@@ -43,8 +43,9 @@ def run_training_session() -> None:
         except (KeyboardInterrupt, EOFError):
             print("\n--- [TRAINER]: Interrupted. Exiting training session. ---")
             break
-        except Exception as e:
-            print(f"!!! [TRAINER]: An error occurred during the chat loop: {e} !!!")
+        except Exception as exc:
+            print(f"!!! [TRAINER]: An error occurred during the chat loop: {exc} !!!")
+            traceback.print_exc()
 
 
 if __name__ == "__main__":

--- a/setup/render_model.py
+++ b/setup/render_model.py
@@ -45,6 +45,8 @@ def render_axiom_model() -> None:
     print(f"✅ Created version metadata file for model {timestamp}.")
 
     output_filename = f"rendered/axiom_model_{timestamp}.axm"
+    output_directory = os.path.dirname(output_filename)
+    os.makedirs(output_directory, exist_ok=True)
     try:
         with zipfile.ZipFile(output_filename, "w", zipfile.ZIP_DEFLATED) as zf:
             zf.write(brain_file, arcname="brain.json")

--- a/setup/render_model.py
+++ b/setup/render_model.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import json
 
 # render_model.py
-import os
 import zipfile
 from datetime import datetime
-from typing import Any
+from pathlib import Path
 
 
 def render_axiom_model() -> None:
@@ -21,10 +20,11 @@ def render_axiom_model() -> None:
 
     print(f"--- Starting Axiom Mind Renderer [Model ID: {timestamp}] ---")
 
-    brain_file = "brain/my_agent_brain.json"
-    cache_file = "brain/interpreter_cache.json"
+    brain_folder = Path("brain")
+    brain_file = brain_folder / "my_agent_brain.json"
+    cache_file = brain_folder / "interpreter_cache.json"
 
-    if not os.path.exists(brain_file):
+    if not brain_file.exists():
         print(f"❌ CRITICAL ERROR: Source file '{brain_file}' not found.")
         print(
             "Please ensure the agent has been run at least once to generate its brain.",
@@ -38,42 +38,43 @@ def render_axiom_model() -> None:
         "version": timestamp,
         "render_date_utc": datetime.utcnow().isoformat(),
     }
-    version_filename = "version.json"
-    with open(version_filename, "w") as f:
-        json.dump(version_data, f, indent=2)
+    # version_file = Path("version.json")
+    # with version_file.open("w", encoding="utf-8") as fp:
+    #     json.dump(version_data, fp, indent=2)
 
-    print(f"✅ Created version metadata file for model {timestamp}.")
+    # print(f"✅ Created version metadata file for model {timestamp}.")
 
-    output_filename = f"rendered/axiom_model_{timestamp}.axm"
-    output_directory = os.path.dirname(output_filename)
-    os.makedirs(output_directory, exist_ok=True)
+    rendered_folder = Path("rendered")
+    output_filename = rendered_folder / f"axiom_model_{timestamp}.axm"
+    output_filename.parent.mkdir(exist_ok=True)
     try:
         with zipfile.ZipFile(output_filename, "w", zipfile.ZIP_DEFLATED) as zf:
             zf.write(brain_file, arcname="brain.json")
             print(f"   - Compressing {brain_file}...")
 
-            if os.path.exists(cache_file):
+            if cache_file.exists():
                 zf.write(cache_file, arcname="cache.json")
                 print(f"   - Compressing {cache_file}...")
             else:
-                empty_cache: dict[str, list[Any]] = {
+                empty_cache: dict[str, list[object]] = {
                     "interpretations": [],
                     "synthesis": [],
                 }
                 zf.writestr("cache.json", json.dumps(empty_cache))
                 print("   - Cache file not found. Packaging an empty cache.")
 
-            zf.write(version_filename, arcname="version.json")
-            print(f"   - Compressing {version_filename}...")
+            # zf.write(version_file, arcname="version.json")
+            zf.writestr("version.json", json.dumps(version_data, indent=2))
+            print("   - Compressing version.json...")
 
         print(f"\n✅ Successfully rendered model: {output_filename}")
 
     except Exception as e:
         print(f"❌ CRITICAL ERROR: Failed to create the .axm package. Error: {e}")
-    finally:
-        if os.path.exists(version_filename):
-            os.remove(version_filename)
-            print("🧹 Cleaned up temporary files.")
+    # finally:
+    #     if version_file.exists():
+    #         version_file.unlink()
+    #         print("🧹 Cleaned up temporary files.")
 
 
 if __name__ == "__main__":

--- a/src/axiom/cognitive_agent.py
+++ b/src/axiom/cognitive_agent.py
@@ -829,11 +829,11 @@ class CognitiveAgent:
         objects_to_process = []
         if isinstance(object_, list):
             for item in object_:
-                name = (
-                    item.get("entity") or item.get("name")
-                    if isinstance(item, dict)
-                    else item
-                )
+                if isinstance(item, dict):
+                    name = item.get("entity") or item.get("name")
+                else:
+                    name = item
+
                 if name:
                     objects_to_process.append(name)
         else:
@@ -884,46 +884,6 @@ class CognitiveAgent:
                                 "conflicting_relation": relation_type,
                             }
                             return (False, question)
-
-        learned_at_least_one = False
-        for object_name in objects_to_process:
-            relation_type = self._get_relation_type(
-                verb_cleaned,
-                subject_name,
-                object_name,
-            )
-            obj_node = self._add_or_update_concept(object_name)
-            if sub_node and obj_node:
-                edge_exists = any(
-                    edge.type == relation_type and edge.target == obj_node.id
-                    for edge in self.graph.get_edges_from_node(sub_node.id)
-                )
-
-                if not edge_exists:
-                    self.graph.add_edge(
-                        sub_node,
-                        obj_node,
-                        relation_type,
-                        0.9,
-                        properties=properties,
-                    )
-                    print(
-                        f"    Learned new fact: {sub_node.name} --[{relation_type}]--> {obj_node.name} with properties {properties}",
-                    )
-                    learned_at_least_one = True
-                else:
-                    print(
-                        f"    - Fact already exists: {sub_node.name} --[{relation_type}]--> {obj_node.name}",
-                    )
-
-        if learned_at_least_one:
-            self._gather_facts_multihop.cache_clear()
-            print("  [Cache]: Cleared reasoning cache due to new knowledge.")
-            self.save_brain()
-            self.save_state()
-            return (True, "I understand. I have noted that.")
-
-        return (True, "I have processed that information.")
 
         learned_at_least_one = False
         for object_name in objects_to_process:

--- a/src/axiom/graph_core.py
+++ b/src/axiom/graph_core.py
@@ -353,6 +353,20 @@ class ConceptGraph:
             edges.append(RelationshipEdge.from_dict(full_edge_data))
         return edges
 
+    def get_all_edges(self) -> list[RelationshipEdge]:
+        """Retrieve all edges in the graph as RelationshipEdge objects.
+
+        Returns:
+            A list of all RelationshipEdge objects in the graph.
+        """
+        reconstructed_edges = []
+        for u, v, data in self.graph.edges(data=True):
+            full_data = data.copy()
+            full_data["source"] = u
+            full_data["target"] = v
+            reconstructed_edges.append(RelationshipEdge.from_dict(full_data))
+        return reconstructed_edges
+
     def decay_activations(self, decay_rate: float = 0.1) -> None:
         """Apply a decay function to the activation level of all nodes.
 

--- a/src/axiom/symbolic_parser.py
+++ b/src/axiom/symbolic_parser.py
@@ -112,7 +112,9 @@ class SymbolicParser:
                     f"  [Symbolic Parser]: Successfully parsed Prepositional structure: '{subject}' -> '{relation_type}' -> '{prep_object}'.",
                 )
                 relation = RelationData(
-                    subject=subject, verb=relation_type, object=prep_object,
+                    subject=subject,
+                    verb=relation_type,
+                    object=prep_object,
                 )
                 return InterpretData(
                     intent="statement_of_fact",

--- a/src/axiom/symbolic_parser.py
+++ b/src/axiom/symbolic_parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from .universal_interpreter import InterpretData, RelationData
@@ -19,6 +20,24 @@ class SymbolicParser:
     This parser is designed to be the first-pass interpreter, allowing the
     agent to bypass the LLM for sentences it can understand on its own.
     """
+
+    PREPOSITION_PATTERN = re.compile(
+        r"^(?P<subject>.+?)\s+"
+        r"(?P<verb>is|are|was|were)\s+"
+        r"(?P<object>.+?)\s+"
+        r"(?P<preposition>in|on|at|of|from|with|inside)\s+"
+        r"(?P<prep_object>.+?)$",
+        re.IGNORECASE,
+    )
+
+    PREPOSITION_TO_RELATION_MAP = {
+        ("is", "in"): "is_located_in",
+        ("are", "in"): "is_located_in",
+        ("is", "on"): "is_located_on",
+        ("are", "on"): "is_located_on",
+        ("is", "at"): "is_located_at",
+        ("are", "at"): "is_located_at",
+    }
 
     def __init__(self, agent: CognitiveAgent):
         """Initialize the SymbolicParser.
@@ -76,6 +95,36 @@ class SymbolicParser:
                 key_topics=["show all facts"],
                 full_text_rephrased="User issued a command to show all facts.",
             )
+
+        preposition_match = self.PREPOSITION_PATTERN.match(text)
+        if preposition_match:
+            groups = preposition_match.groupdict()
+            subject = self.agent._clean_phrase(groups["subject"])
+            verb = groups["verb"].lower()
+            object_phrase = self.agent._clean_phrase(groups["object"])
+            preposition = groups["preposition"].lower()
+            prep_object = self.agent._clean_phrase(groups["prep_object"])
+
+            relation_type = self.PREPOSITION_TO_RELATION_MAP.get((verb, preposition))
+
+            if relation_type:
+                print(
+                    f"  [Symbolic Parser]: Successfully parsed Prepositional structure: '{subject}' -> '{relation_type}' -> '{prep_object}'.",
+                )
+                relation = RelationData(
+                    subject=subject, verb=relation_type, object=prep_object,
+                )
+                return InterpretData(
+                    intent="statement_of_fact",
+                    entities=[
+                        {"name": subject, "type": "CONCEPT"},
+                        {"name": prep_object, "type": "CONCEPT"},
+                        {"name": object_phrase, "type": "CONCEPT"},
+                    ],
+                    relation=relation,
+                    key_topics=[subject, prep_object, object_phrase],
+                    full_text_rephrased=text,
+                )
 
         verb_info = self._find_verb(words)
         if not verb_info:

--- a/src/axiom/universal_interpreter.py
+++ b/src/axiom/universal_interpreter.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, TypedDict, cast
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias, TypedDict, cast
 
 from llama_cpp import Llama
 
@@ -54,7 +54,7 @@ class PropertyData(TypedDict):
 class RelationData(TypedDict):
     subject: str
     verb: str
-    object: str | dict[str, Any] | list[str | dict[str, Any]]
+    object: str | dict[str, str] | list[str | dict[str, str]]
     properties: NotRequired[PropertyData]
 
 

--- a/src/axiom/universal_interpreter.py
+++ b/src/axiom/universal_interpreter.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Final, Literal, TypeAlias, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, TypedDict, cast
 
 from llama_cpp import Llama
 
@@ -54,7 +54,7 @@ class PropertyData(TypedDict):
 class RelationData(TypedDict):
     subject: str
     verb: str
-    object: str
+    object: str | dict[str, Any] | list[str | dict[str, Any]]
     properties: NotRequired[PropertyData]
 
 


### PR DESCRIPTION
This PR fixes a critical MyPy `[unreachable]` error and enhances the symbolic parser.

### Files Edited:

*   **`universal_interpreter.py`**:
    Corrected the `RelationData` type hint for the `object` key. It now accurately reflects that the object can be a `str`, `dict`, or `list`, which was the root cause of the static analysis error.

*   **`cognitive_agent.py`**:
    Changed the logic that processes the `object_` of a fact, replacing a complex one-liner with an explicit `if/else` block to create a clear type guard that satisfies MyPy 👍 

*   **`symbolic_parser.py`**:
    Added a new feature to parse sentences with prepositional phrases (e.g., "Paris is in France"), mapping them to canonical graph relations like `is_located_in`. should build upon this further but this is just an initial expansion of the parser.

*   **`render_model.py`**:
    Added a missing feature that creates the rendered/ folder incase none exists to fix the critical error when rendering. I should have done the same with the brain/ folder :/
      